### PR TITLE
Add Dependabot config for NuGet and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Warsaw"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Warsaw"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       time: "08:00"
       timezone: "Europe/Warsaw"
     open-pull-requests-limit: 5
+    target-branch: "work"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -17,3 +18,4 @@ updates:
       time: "08:00"
       timezone: "Europe/Warsaw"
     open-pull-requests-limit: 5
+    target-branch: "work"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# Manual run (on-demand): GitHub UI -> Insights -> Dependency graph -> Dependabot -> Check for updates
 version: 2
 updates:
   - package-ecosystem: "nuget"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
       time: "08:00"
       timezone: "Europe/Warsaw"
     open-pull-requests-limit: 5
-    target-branch: "work"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -18,4 +17,3 @@ updates:
       time: "08:00"
       timezone: "Europe/Warsaw"
     open-pull-requests-limit: 5
-    target-branch: "work"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,9 @@ name: Build and Test
 
 on:
   push:
-    branches: [master]
+    branches: [master, work]
   pull_request:
-    branches: [master]
+    branches: [master, work]
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,10 @@ name: Build and Test
 
 on:
   push:
-    branches: [master, work]
+    branches: [master]
   pull_request:
-    branches: [master, work]
+    branches: [master]
+  workflow_dispatch:
 
 jobs:
   build-and-test:


### PR DESCRIPTION
### Motivation
- Add Dependabot configuration to automate dependency updates for `nuget` and `github-actions` on a monthly schedule in the repository.

### Description
- Add `/.github/dependabot.yml` with `version: 2` and two `updates` entries configuring `package-ecosystem` `nuget` and `github-actions` to run monthly on `monday` at `08:00` in timezone `Europe/Warsaw` and set `open-pull-requests-limit: 5`.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e81310a88322bb3adec1338bd458)