### PR TITLE
Validate image bounds before decoding

### DIFF
--- a/src/PrivatePdfConverter/Commands/DirToPdf.cs
+++ b/src/PrivatePdfConverter/Commands/DirToPdf.cs
@@ -29,7 +29,7 @@ public static class DirToPdf
         }
         catch (InvalidDataException ex)
         {
-            Log.Logger.Error(ex.Message);
+            Log.Logger.Error(ex, ex.Message);
             return;
         }
 

--- a/src/PrivatePdfConverter/Commands/DirToPdf.cs
+++ b/src/PrivatePdfConverter/Commands/DirToPdf.cs
@@ -23,7 +23,15 @@ public static class DirToPdf
         }
 
         using var images = new MagickImageCollection();
-        supportedFiles.ForEach(x => images.Add(new MagickImage(x)));
+        try
+        {
+            supportedFiles.ForEach(x => images.Add(FileService.LoadValidatedImage(x)));
+        }
+        catch (InvalidDataException ex)
+        {
+            Log.Logger.Error(ex.Message);
+            return;
+        }
 
         SaveAsPdf(path, images, output);
     }

--- a/src/PrivatePdfConverter/Commands/DirToPdf.cs
+++ b/src/PrivatePdfConverter/Commands/DirToPdf.cs
@@ -23,14 +23,15 @@ public static class DirToPdf
         }
 
         using var images = new MagickImageCollection();
-        try
+        foreach (var file in supportedFiles)
         {
-            supportedFiles.ForEach(x => images.Add(FileService.LoadValidatedImage(x)));
-        }
-        catch (InvalidDataException ex)
-        {
-            Log.Logger.Error(ex, ex.Message);
-            return;
+            var image = FileService.LoadValidatedImage(file);
+            if (image is null)
+            {
+                return;
+            }
+
+            images.Add(image);
         }
 
         SaveAsPdf(path, images, output);

--- a/src/PrivatePdfConverter/Commands/ImgToPdf.cs
+++ b/src/PrivatePdfConverter/Commands/ImgToPdf.cs
@@ -23,7 +23,15 @@ public static class ImgToPdf
         Log.Logger.Information("Read 1 file with name: {FileName}, Full path: '{Path}'", Path.GetFileName(path), path);
 
         using var images = new MagickImageCollection();
-        images.Add(new MagickImage(path));
+        try
+        {
+            images.Add(FileService.LoadValidatedImage(path));
+        }
+        catch (InvalidDataException ex)
+        {
+            Log.Logger.Error(ex.Message);
+            return;
+        }
 
         SaveAsPdf(path, images, output);
     }

--- a/src/PrivatePdfConverter/Commands/ImgToPdf.cs
+++ b/src/PrivatePdfConverter/Commands/ImgToPdf.cs
@@ -29,7 +29,7 @@ public static class ImgToPdf
         }
         catch (InvalidDataException ex)
         {
-            Log.Logger.Error(ex.Message);
+            Log.Logger.Error(ex, ex.Message);
             return;
         }
 

--- a/src/PrivatePdfConverter/Commands/ImgToPdf.cs
+++ b/src/PrivatePdfConverter/Commands/ImgToPdf.cs
@@ -23,16 +23,13 @@ public static class ImgToPdf
         Log.Logger.Information("Read 1 file with name: {FileName}, Full path: '{Path}'", Path.GetFileName(path), path);
 
         using var images = new MagickImageCollection();
-        try
+        var image = FileService.LoadValidatedImage(path);
+        if (image is null)
         {
-            images.Add(FileService.LoadValidatedImage(path));
-        }
-        catch (InvalidDataException ex)
-        {
-            Log.Logger.Error(ex, ex.Message);
             return;
         }
 
+        images.Add(image);
         SaveAsPdf(path, images, output);
     }
 

--- a/src/PrivatePdfConverter/Services/FileService.cs
+++ b/src/PrivatePdfConverter/Services/FileService.cs
@@ -1,9 +1,14 @@
+using ImageMagick;
 using Serilog;
 
 namespace PrivatePdfConverter.Services;
 
 public static class FileService
 {
+    private const ulong MaxWidth = 10_000;
+    private const ulong MaxHeight = 10_000;
+    private const ulong MaxArea = 100_000_000;
+
     public static IEnumerable<string> ValidExtensions { get; } =
     [
         "jpg", "jpeg", "bmp", "gif", "png", "tif", "tiff", "webp"
@@ -11,6 +16,29 @@ public static class FileService
 
     public static bool IsImage(this string? extension)
         => !string.IsNullOrEmpty(extension) && ValidExtensions.Contains(extension.ToLower()[1..]);
+
+    public static MagickImage LoadValidatedImage(string path)
+    {
+        using var headerImage = new MagickImage();
+        headerImage.Ping(path);
+
+        var width = headerImage.Width;
+        var height = headerImage.Height;
+        var area = (ulong)width * height;
+
+        if (width == 0 || height == 0)
+        {
+            throw new InvalidDataException($"Image '{path}' has invalid dimensions {width}x{height}.");
+        }
+
+        if ((ulong)width > MaxWidth || (ulong)height > MaxHeight || area > MaxArea)
+        {
+            throw new InvalidDataException(
+                $"Image '{path}' exceeds the supported limits ({width}x{height}, area {area}).");
+        }
+
+        return new MagickImage(path);
+    }
 
     public static IEnumerable<string> LoadFilePathsFromDirectory(this string path, string searchPattern = "*")
     {

--- a/src/PrivatePdfConverter/Services/FileService.cs
+++ b/src/PrivatePdfConverter/Services/FileService.cs
@@ -5,6 +5,8 @@ namespace PrivatePdfConverter.Services;
 
 public static class FileService
 {
+    // Conservative defaults chosen to allow typical high-resolution images
+    // while rejecting obviously pathological dimensions before full decode.
     private const ulong MaxWidth = 10_000;
     private const ulong MaxHeight = 10_000;
     private const ulong MaxArea = 100_000_000;
@@ -17,7 +19,7 @@ public static class FileService
     public static bool IsImage(this string? extension)
         => !string.IsNullOrEmpty(extension) && ValidExtensions.Contains(extension.ToLower()[1..]);
 
-    public static MagickImage LoadValidatedImage(string path)
+    public static MagickImage? LoadValidatedImage(string path)
     {
         using var headerImage = new MagickImage();
         headerImage.Ping(path);
@@ -28,13 +30,19 @@ public static class FileService
 
         if (width == 0 || height == 0)
         {
-            throw new InvalidDataException($"Image '{path}' has invalid dimensions {width}x{height}.");
+            Log.Logger.Error("Image '{Path}' has invalid dimensions {Width}x{Height}.", path, width, height);
+            return null;
         }
 
-        if ((ulong)width > MaxWidth || (ulong)height > MaxHeight || area > MaxArea)
+        if (width > MaxWidth || height > MaxHeight || area > MaxArea)
         {
-            throw new InvalidDataException(
-                $"Image '{path}' exceeds the supported limits ({width}x{height}, area {area}).");
+            Log.Logger.Error(
+                "Image '{Path}' exceeds the supported limits ({Width}x{Height}, area {Area}).",
+                path,
+                width,
+                height,
+                area);
+            return null;
         }
 
         return new MagickImage(path);


### PR DESCRIPTION
## Summary

This PR adds metadata validation before full image decode in the img and dir commands.

## Problem

Untrusted image files were previously accepted based only on file extension and then passed directly to ImageMagick for full decode. A malicious image could declare enormous dimensions, causing excessive memory and disk usage during PDF generation.

## Changes

- add FileService.LoadValidatedImage(...)
- read image metadata with Ping(...) before full decode
- reject images with invalid dimensions
- reject images that exceed maximum width, height, or total pixel area
- use the validated loader in ImgToPdf and DirToPdf
- log a clean error message instead of printing a stack trace for rejected input

## Result

This prevents oversized image inputs such as lottapixel.jpg from reaching full decode and mitigates the denial-of-service condition reported in the disclosure.

## Context

This PR follows the vulnerability disclosure discussed with the maintainer by email on April 12, 2026, where the report was acknowledged as valid and a PR was requested.